### PR TITLE
#5 Multi-Line Build Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ into a database.
 
 Building the AWS Lambda zip file:
 
-1. `cd ~/cisagov/findings-data-import-lambda`
-1. `docker-compose down`
-1. `docker-compose build`
-1. `docker-compose up`
+```console
+cd ~/cisagov/findings-data-import-lambda
+docker-compose down
+docker-compose build
+docker-compose up
+```
 
 ## Fields to Replace ##
 


### PR DESCRIPTION
Edited README.md so that build instructions for AWS zip file are multi-line and not individual code lines.