### PR TITLE
Removed Fields to Replace JSON & Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,22 @@ docker-compose up
 
 ## Fields to Replace ##
 
-The `fields_filename` flag is leveraged to dynamically tell the script
+The `--fields-filename` flag is leveraged to dynamically tell the script
 which fields to remove and/or change. As the input JSON structure changes, the
 script is capable of adapting to new or changing field name requirements. In
 the JSON file, it follows a key/value methodology, where the key is the
-original field name to find in the input JSON and the value is the new field
-name desired. If the value is blank, the script will remove that JSON element
-from the record.
+original field name (designated by the "field_to_replace" field in the example
+below) to find in the input JSON and the value (designated by the
+"value_to_replace_field_with" field in the example below) is the new field name
+desired. If the value is blank, the script will remove that JSON element from
+the record.
 
 ### Example JSON Fields to Replace File ###
 
 ```json
 {
     "field_to_replace": "value_to_replace_field_with",
-    "field_to_remove": "" // Empty quotes designate a field to remove
+    "field_to_remove": ""
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,22 @@ docker-compose up
 
 ## Fields to Replace ##
 
-The `fields_to_replace.json` file is leveraged to dynamically tell the script
+The `fields_filename` flag is leveraged to dynamically tell the script
 which fields to remove and/or change. As the input JSON structure changes, the
 script is capable of adapting to new or changing field name requirements. In
 the JSON file, it follows a key/value methodology, where the key is the
 original field name to find in the input JSON and the value is the new field
 name desired. If the value is blank, the script will remove that JSON element
 from the record.
+
+### Example JSON Fields to Replace File ###
+
+```json
+{
+    "field_to_replace": "value_to_replace_field_with",
+    "field_to_remove": "" // Empty quotes designate a field to remove
+}
+```
 
 ## Note ##
 

--- a/fields_to_replace.json
+++ b/fields_to_replace.json
@@ -1,6 +1,0 @@
-{
-  "ASMT ID": "RVA ID",
-  "Manual/Tool": "Man/Tool",
-  "Std Text Modify": "Std Txt Modify",
-  "_id": ""
-}


### PR DESCRIPTION
Per issue #10, I updated repository to remove fields_to_replace.json file and updated README to include more specific instructions on how the --fields-filename flag is leveraged within the script. Since the script is pulling the fields_to_replace file from S3 using the --fields-filename as the filename, the fields_to_replace.json file is not needed in the repository. This file will be generated by the user of the script and placed in S3. 

The README was updated to include an inline example using the appropriate markdown. The language was also cleaned up to provide clearer instructions and descriptions for what's going on.