### PR TITLE
Making Logging Great Again

### DIFF
--- a/fdi/findings_data_import.py
+++ b/fdi/findings_data_import.py
@@ -263,7 +263,7 @@ def import_data(
                 )
 
         logging.info(
-            f"{processed_findings}/{len(findings_data)} documents successfully processed."
+            f"{processed_findings}/{len(findings_data)} documents successfully processed from '{data_filename}'."
         )
 
         if save_succeeded:


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This small PR is focused on making logging more informative when records are skipped and end results for a particular uploaded object.

Some code is also DRYed for moving S3 objects after processing is finished or if there is an error.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
Previously there was only a summary logged after processing an uploaded JSON. These changes make it clear why a record was skipped and for which file the logging output pertains.

The code to move files after processing or in the event of an error is almost identical and so it was moved into a function with necessary parameters to cut down on code duplication.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I tested this in my testing workspace and verified that log output was as expected.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
