### PR TITLE
Replace existing codeowners with @Yablargo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @mcdonnnj @mzack5020
+* @Yablargo
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.


### PR DESCRIPTION
## 🗣 Description ##

This pull request replaces the existing codeowners with @Yablargo.

## 💭 Motivation and context ##

@Yablargo is the current maintainer of this code, and if he moves on then the product owner should choose a different maintainer.

## 🧪 Testing ##

Eyeballs.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).